### PR TITLE
Tweaked compilation options

### DIFF
--- a/Compiler/src/main.c
+++ b/Compiler/src/main.c
@@ -148,9 +148,8 @@ void printMakeFile(string output_dir, string install_dir)
    fprintf(makefile, "OBJECTS := $(patsubst %%.c, %%.o, $(wildcard *.c))\n");  
    fprintf(makefile, "CC=gcc\n\n");
 
-   if(debug_flags) fprintf(makefile, "CFLAGS = -g -L$(LIB) -Wall -Wextra -lgp2\n\n");
-   else fprintf(makefile, "CFLAGS = -I$(INCDIR) -L$(LIBDIR) -fomit-frame-pointer "
-                          "-O2 -Wall -Wextra -lgp2\n\n");
+   if(debug_flags) fprintf(makefile, "CFLAGS = -g -I$(INCDIR) -L$(LIBDIR) -Og -Wall -Wextra -lgp2\n\n");
+   else fprintf(makefile, "CFLAGS = -I$(INCDIR) -L$(LIBDIR) -O3 -Wall -Wextra -lgp2\n\n");
    fprintf(makefile, "default:\t$(OBJECTS)\n\t\t$(CC) $(OBJECTS) $(CFLAGS) -o gp2run\n\n");
    fprintf(makefile, "%%.o:\t\t%%.c\n\t\t$(CC) -c $(CFLAGS) -o $@ $<\n\n");
    fprintf(makefile, "clean:\t\n\t\trm *\n");


### PR DESCRIPTION
We should probably compile with all of the optimizations GCC has to give us (`-O3`). In debug mode, however, we should explicitly ask GCC to give us the optimizations suitable for debugging. Also, in debug mode, we should still pass the lib directory.